### PR TITLE
add additionalPrintColumns for podgroup crd

### DIFF
--- a/config/crd/bases/scheduling.godel.kubewharf.io_podgroups.yaml
+++ b/config/crd/bases/scheduling.godel.kubewharf.io_podgroups.yaml
@@ -16,7 +16,26 @@ spec:
     singular: podgroup
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The current status of the PodGroup
+      jsonPath: .status.phase
+      name: Status
+      priority: 1
+      type: string
+    - description: The minimal number of members/tasks to run the PodGroup
+      jsonPath: .spec.minMember
+      name: MinMember
+      priority: 1
+      type: integer
+    - description: The maximal time of tasks to wait before run the PodGroup
+      jsonPath: .spec.scheduleTimeoutSeconds
+      name: TimeoutSeconds
+      priority: 1
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PodGroup indicates a collection of Pods which will be used for

--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -94,6 +94,10 @@ type SchedulerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",priority=1,description="The current status of the PodGroup"
+// +kubebuilder:printcolumn:name="MinMember",type="integer",JSONPath=".spec.minMember",priority=1,description="The minimal number of members/tasks to run the PodGroup"
+// +kubebuilder:printcolumn:name="TimeoutSeconds",type="integer",JSONPath=".spec.scheduleTimeoutSeconds",priority=1,description="The maximal time of tasks to wait before running the PodGroup"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type PodGroup struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.


### PR DESCRIPTION
add `additionalPrintColumns` for podgroup crd, in order to display status、min member、timeout seconds when use kubectl

```sh
k get podgroup -o wide

NAME    STATUS    MINMEMBER   TIMEOUTSECONDS   AGE
test-pg   Timeout   10          600              2d16h
```